### PR TITLE
support for Elasticsearch 6.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "ajk.gradle.elastic"
-version = "0.0.19"
+version = "0.0.20"
 
 String repoName = 'bilberry'
 

--- a/src/main/groovy/ajk/gradle/elastic/ElasticActions.groovy
+++ b/src/main/groovy/ajk/gradle/elastic/ElasticActions.groovy
@@ -59,15 +59,29 @@ class ElasticActions {
 
     println "${CYAN}* elastic:$NORMAL installing elastic version $version"
 
-    String linuxUrl = "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${version}.tar.gz"
-    String winUrl = "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${version}.zip"
+    def majorVersion = Integer.valueOf( version.split( "\\." )[0] )
 
-    if (version.startsWith("5")) {
-      linuxUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}.tar.gz"
-      winUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}.zip"
-    } else if (version.startsWith("2")) {
-      linuxUrl = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${version}/elasticsearch-${version}.tar.gz"
-      winUrl = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/${version}/elasticsearch-${version}.zip"
+    String linuxUrl
+    String winUrl
+
+    switch (majorVersion) {
+      case  0:
+      case  1:
+        linuxUrl = "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${version}.tar.gz"
+        winUrl = "https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-${version}.zip"
+        break
+
+      case  2:
+        linuxUrl = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${version}/elasticsearch-${version}.tar.gz"
+        winUrl = "https://download.elasticsearch.org/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/${version}/elasticsearch-${version}.zip"
+        break
+
+      // there are no versions 3 and 4
+
+      default: // catches version 5 and up
+        linuxUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}.tar.gz"
+        winUrl = "https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${version}.zip"
+        break
     }
 
     String elasticPackage = isFamily(FAMILY_WINDOWS) ? winUrl : linuxUrl

--- a/src/main/groovy/ajk/gradle/elastic/StartElasticAction.groovy
+++ b/src/main/groovy/ajk/gradle/elastic/StartElasticAction.groovy
@@ -69,7 +69,7 @@ class StartElasticAction {
         logsDir.mkdirs()
         dataDir.mkdirs()
 
-        def optPrefix = elastic.version.startsWith("5") ? "-E" : "-Des."
+        def optPrefix = Integer.valueOf( elastic.version.split( "\\." )[0]) >= 5 ? "-E" : "-Des."
         File esScript = new File("${elastic.home}/bin/elasticsearch${isFamily(FAMILY_WINDOWS) ? '.bat' : ''}")
         def command = [
                 esScript.absolutePath,
@@ -90,7 +90,7 @@ class StartElasticAction {
             "ES_HOME=$elastic.home"
         ]
 
-        if(elastic.version.startsWith("5")) {
+        if (Integer.valueOf( elastic.version.split( "\\." )[0]) >= 5) {
             esEnv += [
                 "ES_JAVA_OPTS=-Xms128m -Xmx512m"
             ]

--- a/src/main/groovy/ajk/gradle/elastic/StopElasticAction.groovy
+++ b/src/main/groovy/ajk/gradle/elastic/StopElasticAction.groovy
@@ -37,7 +37,7 @@ class StopElasticAction {
         println "${CYAN}* elastic:$NORMAL stopping ElasticSearch"
 
         try {
-            if (elastic.version.startsWith("2") || elastic.version.startsWith("5")) {
+            if (Integer.valueOf( elastic.version.split( "\\." )[0]) >= 2) {
                 def pidFile = new File(elastic.home, 'elastic.pid')
                 if (!pidFile.exists()) {
                     println "${RED}* elastic:$NORMAL ${pidFile} not found"


### PR DESCRIPTION
presumes things won’t change from es 5.x upward, of course that’s unreasonable, but works for 5.x and 6.x.