### PR TITLE
Chmod +x for controller file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Plugin setup with gradle >= 2.1:
 ```gradle
 
     plugins {
-        id "ajk.gradle.elastic" version "0.0.20"
+        id "ajk.gradle.elastic" version "0.0.21"
     }
 ```
 
@@ -25,7 +25,7 @@ Plugin setup with gradle < 2.1:
             maven { url "http://dl.bintray.com/amirk/maven" }
         }
         dependencies {
-            classpath("ajk.gradle.elastic:gradle-elastic-plugin:0.0.20")
+            classpath("ajk.gradle.elastic:gradle-elastic-plugin:0.0.21")
         }
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 group = "ajk.gradle.elastic"
-version = "0.0.20"
+version = "0.0.21"
 
 String repoName = 'bilberry'
 

--- a/src/main/groovy/ajk/gradle/elastic/ElasticActions.groovy
+++ b/src/main/groovy/ajk/gradle/elastic/ElasticActions.groovy
@@ -106,6 +106,9 @@ class ElasticActions {
       }
       ant.chmod(file: new File("$home/bin/elasticsearch"), perm: "+x")
       ant.chmod(file: new File("$home/bin/plugin"), perm: "+x")
+      // controller is used to start the elastic server
+      ant.chmod(file: new File("$home/modules/x-pack-ml/platform/linux-x86_64/bin/controller"), perm: "+x")
+      ant.chmod(file: new File("$home/modules/x-pack-ml/platform/darwin-x86_64/bin/controller"), perm: "+x")
     }
 
     new File("$home/version.txt") << "$version"


### PR DESCRIPTION
When using version 6.7.0 of elastic search, there is an error coming from the startServer call because of incorrect permissions of the controller file.

```
* elastic: installing elastic version 6.7.0
* elastic: starting ElasticSearch at .../gradle/tools/elastic using http port 9202 and tcp transport port 9302
* elastic: ElasticSearch data directory: .../build/elastic6
* elastic: ElasticSearch logs directory: .../build/elastic6/logs
* elastic: waiting for ElasticSearch to start
[2019-04-30T11:48:25,948][WARN ][o.e.b.ElasticsearchUncaughtExceptionHandler] [unknown] uncaught exception in thread [main]
org.elasticsearch.bootstrap.StartupException: org.elasticsearch.bootstrap.BootstrapException:
java.io.IOException: Cannot run program 
".../gradle/tools/elastic/modules/x-pack-ml/platform/darwin-x86_64/bin/controller": error=13, Permission denied
```

This change will add +x to this file and the comparable file in `linux-x86_64/bin`